### PR TITLE
Meilisearch v0.21.0

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -63,7 +63,7 @@ jobs:
       run: |
         poetry install
     - name: MeiliSearch (latest version) setup with Docker
-      run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --no-analytics=true --master-key=masterKey
+      run: docker run -d -p 7700:7700 getmeili/meilisearch:v0.21.0rc1 ./meilisearch --no-analytics=true --master-key=masterKey
     - name: Test with pytest
       run: |
         poetry run pytest --cov=meilisearch_python_async --cov-report=xml

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -63,7 +63,7 @@ jobs:
       run: |
         poetry install
     - name: MeiliSearch (latest version) setup with Docker
-      run: docker run -d -p 7700:7700 getmeili/meilisearch:v0.21.0rc1 ./meilisearch --no-analytics=true --master-key=masterKey
+      run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --no-analytics=true --master-key=masterKey
     - name: Test with pytest
       run: |
         poetry run pytest --cov=meilisearch_python_async --cov-report=xml

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ SearchResults(
 
 ## Compatibility with MeiliSearch
 
-This package only guarantees the compatibility with [version v0.20.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.20.0).
+This package only guarantees the compatibility with [version v0.21.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.21.0).
 
 ## MeiliSearch v0.21.0
 

--- a/README.md
+++ b/README.md
@@ -295,13 +295,6 @@ SearchResults(
 
 This package only guarantees the compatibility with [version v0.21.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.21.0).
 
-## MeiliSearch v0.21.0
-
-If you would like to try out v0.21.0 release candidate of MeiliSearch the `meilisearch-v0.21.0`
-branch contains updates to work with this version. It is not recommend to use the MeiliSearch
-release candidate, and therefore the `meilisearch-v-.21.0` branch of this package, in production.
-Bug reports for this branch are welcome and appreciated.
-
 ## Learn More
 
 For more see the [API Reference](https://docs.meilisearch.com/reference/api/) in the MeiliSearch documentation. Keep in mind you will need to await the examples shown in the documentation, and that you will be getting python objects instead of JSON for you results.

--- a/meilisearch_python_async/index.py
+++ b/meilisearch_python_async/index.py
@@ -277,8 +277,7 @@ class Index:
         query: str,
         offset: int = 0,
         limit: int = 20,
-        filters: Optional[str] = None,
-        facet_filters: Optional[list[str | list[str]]] = None,
+        filter: Optional[str | list[str | list[str]]] = None,
         facets_distribution: Optional[list[str]] = None,
         attributes_to_retrieve: list[str] = ["*"],
         attributes_to_crop: Optional[list[str]] = None,
@@ -292,8 +291,7 @@ class Index:
             query: String containing the word(s) to search
             offset: Number of documents to skip. Defaults to 0.
             limit: Maximum number of documents returned. Defaults to 20.
-            filters: Filter queries by an attribute value. Defaults to None.
-            facet_filters: Facet names and values to filter on. Defaults to None.
+            filter: Filter queries by an attribute value. Defaults to None.
             facets_distribution: Facets for which to retrieve the matching count. Defaults to None.
             attributes_to_retrieve: Attributes to display in the returned documents.
                 Defaults to ["*"].
@@ -315,8 +313,7 @@ class Index:
             "q": query,
             "offset": offset,
             "limit": limit,
-            "filters": filters,
-            "facetFilters": facet_filters,
+            "filter": filter,
             "facetsDistribution": facets_distribution,
             "attributesToRetrieve": attributes_to_retrieve,
             "attributesToCrop": attributes_to_crop,
@@ -1108,17 +1105,17 @@ class Index:
 
         return UpdateId(**response.json())
 
-    async def get_attributes_for_faceting(self) -> Optional[list[str]]:
-        """Get attributes for faceting of the index.
+    async def get_filterable_attributes(self) -> Optional[list[str]]:
+        """Get filterable attributes of the index.
 
         Returns:
-            List containing the attributes for faceting of the index.
+            List containing the filterable attributes of the index.
 
         Raises:
             MeilisearchCommunicationError: If there was an error communicating with the server.
             MeilisearchApiError: If the MeiliSearch API returned an error.
         """
-        url = f"indexes/{self.uid}/settings/attributes-for-faceting"
+        url = f"indexes/{self.uid}/settings/filterable-attributes"
         response = await self._http_requests.get(url)
 
         if not response.json():
@@ -1126,11 +1123,11 @@ class Index:
 
         return response.json()
 
-    async def update_attributes_for_faceting(self, body: list[str]) -> UpdateId:
-        """Update attributes for faceting of the index.
+    async def update_filterable_attributes(self, body: list[str]) -> UpdateId:
+        """Update filterable attributes of the index.
 
         Args:
-            body: List containing the attributes for faceting.
+            body: List containing the filterable attributes of the index.
 
         Returns:
             Update id to track the action.
@@ -1139,13 +1136,13 @@ class Index:
             MeilisearchCommunicationError: If there was an error communicating with the server.
             MeilisearchApiError: If the MeiliSearch API returned an error.
         """
-        url = f"indexes/{self.uid}/settings/attributes-for-faceting"
+        url = f"indexes/{self.uid}/settings/filterable-attributes"
         response = await self._http_requests.post(url, body)
 
         return UpdateId(**response.json())
 
-    async def reset_attributes_for_faceting(self) -> UpdateId:
-        """Reset attributes for faceting of the index to default values.
+    async def reset_filterable_attributes(self) -> UpdateId:
+        """Reset filterable attributes of the index to default values.
 
         Returns:
             Update id to track the action.
@@ -1154,7 +1151,7 @@ class Index:
             MeilisearchCommunicationError: If there was an error communicating with the server.
             MeilisearchApiError: If the MeiliSearch API returned an error.
         """
-        url = f"indexes/{self.uid}/settings/attributes-for-faceting"
+        url = f"indexes/{self.uid}/settings/filterable-attributes"
         response = await self._http_requests.delete(url)
 
         return UpdateId(**response.json())

--- a/meilisearch_python_async/index.py
+++ b/meilisearch_python_async/index.py
@@ -248,7 +248,7 @@ class Index:
         elapsed_time = 0.0
         while elapsed_time < timeout_in_ms:
             get_update = await self.get_update_status(update_id)
-            if get_update.status != "enqueued":
+            if get_update.status in ["processed", "failed"]:
                 return get_update
             await sleep(interval_in_ms / 1000)
             time_delta = datetime.now() - start_time

--- a/meilisearch_python_async/models/index.py
+++ b/meilisearch_python_async/models/index.py
@@ -17,4 +17,4 @@ class IndexInfo(IndexBase):
 class IndexStats(CamelBase):
     number_of_documents: int
     is_indexing: bool
-    fields_distribution: Dict[str, int]
+    field_distribution: Dict[str, int]

--- a/meilisearch_python_async/models/settings.py
+++ b/meilisearch_python_async/models/settings.py
@@ -7,7 +7,7 @@ class MeiliSearchSettings(CamelBase):
     synonyms: Optional[Dict[str, Any]] = None
     stop_words: Optional[List[str]] = None
     ranking_rules: Optional[List[str]] = None
-    attributes_for_faceting: Optional[List[str]] = None
+    filterable_attributes: Optional[List[str]] = None
     distinct_attribute: Optional[str] = None
     searchable_attributes: Optional[List[str]] = None
     displayed_attributes: Optional[List[str]] = None

--- a/meilisearch_python_async/models/version.py
+++ b/meilisearch_python_async/models/version.py
@@ -1,9 +1,9 @@
-from datetime import datetime
+from datetime import date
 
 from camel_converter.pydantic_base import CamelBase
 
 
 class Version(CamelBase):
     commit_sha: str
-    build_date: datetime
+    commit_date: date
     pkg_version: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "meilisearch-python-async"
-version = "0.11.3"
+version = "0.12.0"
 description = "A Python async client for the MeiliSearch API"
 authors = ["Paul Sanders <psanders1@gmail.com>"]
 license = "MIT"

--- a/tests/integration/test_documents.py
+++ b/tests/integration/test_documents.py
@@ -426,12 +426,14 @@ async def test_update_documents_in_batches_with_primary_key(batch_size, test_cli
 @pytest.mark.asyncio
 async def test_update_documents_from_file(test_client, small_movies, small_movies_path):
     small_movies[0]["title"] = "Some title"
+    movie_id = small_movies[0]["id"]
     index = test_client.index("movies")
     response = await index.add_documents(small_movies)
     update = await index.wait_for_pending_update(response.update_id)
     assert await index.get_primary_key() == "id"
     response = await index.get_documents()
-    assert response[0]["title"] == "Some title"
+    got_title = filter(lambda x: x["id"] == movie_id, response)
+    assert list(got_title)[0]["title"] == "Some title"
     update = await index.update_documents_from_file(small_movies_path)
     update = await index.wait_for_pending_update(update.update_id)
     assert update.status == "processed"
@@ -443,12 +445,14 @@ async def test_update_documents_from_file(test_client, small_movies, small_movie
 async def test_update_documents_from_file_string_path(test_client, small_movies, small_movies_path):
     string_path = str(small_movies_path)
     small_movies[0]["title"] = "Some title"
+    movie_id = small_movies[0]["id"]
     index = test_client.index("movies")
     response = await index.add_documents(small_movies)
     update = await index.wait_for_pending_update(response.update_id)
     assert await index.get_primary_key() == "id"
     response = await index.get_documents()
-    assert response[0]["title"] == "Some title"
+    got_title = filter(lambda x: x["id"] == movie_id, response)
+    assert list(got_title)[0]["title"] == "Some title"
     update = await index.update_documents_from_file(string_path)
     update = await index.wait_for_pending_update(update.update_id)
     assert update.status == "processed"
@@ -553,12 +557,14 @@ async def test_update_documents_from_file_in_batches(
     batch_size, test_client, small_movies_path, small_movies
 ):
     small_movies[0]["title"] = "Some title"
+    movie_id = small_movies[0]["id"]
     index = test_client.index("movies")
     response = await index.add_documents(small_movies)
     update = await index.wait_for_pending_update(response.update_id)
     assert await index.get_primary_key() == "id"
     response = await index.get_documents()
-    assert response[0]["title"] == "Some title"
+    got_title = filter(lambda x: x["id"] == movie_id, response)
+    assert list(got_title)[0]["title"] == "Some title"
     updates = await index.update_documents_from_file_in_batches(small_movies_path, batch_size)
     assert ceil(len(small_movies) / batch_size) == len(updates)
 
@@ -577,12 +583,14 @@ async def test_update_documents_from_file_string_path_in_batches(
 ):
     string_path = str(small_movies_path)
     small_movies[0]["title"] = "Some title"
+    movie_id = small_movies[0]["id"]
     index = test_client.index("movies")
     response = await index.add_documents(small_movies)
     update = await index.wait_for_pending_update(response.update_id)
     assert await index.get_primary_key() == "id"
     response = await index.get_documents()
-    assert response[0]["title"] == "Some title"
+    got_title = filter(lambda x: x["id"] == movie_id, response)
+    assert list(got_title)[0]["title"] == "Some title"
     updates = await index.update_documents_from_file_in_batches(string_path, batch_size)
     assert ceil(len(small_movies) / batch_size) == len(updates)
 

--- a/tests/integration/test_index.py
+++ b/tests/integration/test_index.py
@@ -102,7 +102,9 @@ async def test_get_all_update_status_default(empty_index):
 async def test_get_all_update_status(empty_index, small_movies):
     index = await empty_index()
     response = await index.add_documents(small_movies)
+    await index.wait_for_pending_update(response.update_id)
     response = await index.add_documents(small_movies)
+    await index.wait_for_pending_update(response.update_id)
     response = await index.get_all_update_status()
     assert len(response) == 2
 

--- a/tests/integration/test_index.py
+++ b/tests/integration/test_index.py
@@ -18,7 +18,7 @@ def new_settings():
 
 @pytest.fixture
 def default_ranking_rules():
-    return ["typo", "words", "proximity", "attribute", "wordsPosition", "exactness"]
+    return ["words", "typo", "proximity", "attribute", "exactness"]
 
 
 @pytest.fixture
@@ -57,7 +57,7 @@ def new_synonyms():
 
 
 @pytest.fixture
-def attributes_for_faceting():
+def filterable_attributes():
     return ["title", "release_date"]
 
 
@@ -385,32 +385,32 @@ async def test_reset_synonyms(empty_index, new_synonyms):
 
 
 @pytest.mark.asyncio
-async def test_get_attributes_for_faceting(empty_index):
+async def test_get_filterable_attributes(empty_index):
     index = await empty_index()
-    response = await index.get_attributes_for_faceting()
+    response = await index.get_filterable_attributes()
     assert response is None
 
 
 @pytest.mark.asyncio
-async def test_update_attributes_for_faceting(empty_index, attributes_for_faceting):
+async def test_update_filterable_attributes(empty_index, filterable_attributes):
     index = await empty_index()
-    response = await index.update_attributes_for_faceting(attributes_for_faceting)
+    response = await index.update_filterable_attributes(filterable_attributes)
     await index.wait_for_pending_update(response.update_id)
-    response = await index.get_attributes_for_faceting()
-    assert sorted(response) == sorted(attributes_for_faceting)
+    response = await index.get_filterable_attributes()
+    assert sorted(response) == sorted(filterable_attributes)
 
 
 @pytest.mark.asyncio
-async def test_reset_attributes_for_faceting(empty_index, attributes_for_faceting):
+async def test_reset_filterable_attributes(empty_index, filterable_attributes):
     index = await empty_index()
-    response = await index.update_attributes_for_faceting(attributes_for_faceting)
+    response = await index.update_filterable_attributes(filterable_attributes)
     update = await index.wait_for_pending_update(response.update_id)
     assert update.status == "processed"
-    response = await index.get_attributes_for_faceting()
-    assert sorted(response) == sorted(attributes_for_faceting)
-    response = await index.reset_attributes_for_faceting()
+    response = await index.get_filterable_attributes()
+    assert sorted(response) == sorted(filterable_attributes)
+    response = await index.reset_filterable_attributes()
     await index.wait_for_pending_update(response.update_id)
-    response = await index.get_attributes_for_faceting()
+    response = await index.get_filterable_attributes()
     assert response is None
 
 

--- a/tests/integration/test_index.py
+++ b/tests/integration/test_index.py
@@ -119,10 +119,14 @@ async def test_wait_for_pending_update(empty_index, small_movies):
 
 @pytest.mark.asyncio
 async def test_wait_for_pending_update_time_out(empty_index, small_movies):
+    index = await empty_index()
     with pytest.raises(MeiliSearchTimeoutError):
-        index = await empty_index()
         response = await index.add_documents(small_movies)
         await index.wait_for_pending_update(response.update_id, timeout_in_ms=1, interval_in_ms=1)
+
+    await index.wait_for_pending_update(
+        response.update_id
+    )  # Make sure the indexing finishes so subsequent tests don't have issues.
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -80,6 +80,7 @@ async def test_custom_search_params_with_simple_string(index_with_documents):
     assert "release_date" not in response.hits[0]["_formatted"]
 
 
+@pytest.mark.xfail(reason="attributes_to_highlight not working")
 @pytest.mark.asyncio
 async def test_custom_search_params_with_string_list(index_with_documents):
     index = await index_with_documents()
@@ -100,7 +101,7 @@ async def test_custom_search_params_with_string_list(index_with_documents):
 @pytest.mark.asyncio
 async def test_custom_search_params_with_facets_distribution(index_with_documents):
     index = await index_with_documents()
-    update = await index.update_attributes_for_faceting(["genre"])
+    update = await index.update_filterable_attributes(["genre"])
     await index.wait_for_pending_update(update.update_id)
     response = await index.search("world", facets_distribution=["genre"])
     assert len(response.hits) == 12
@@ -115,9 +116,9 @@ async def test_custom_search_params_with_facets_distribution(index_with_document
 @pytest.mark.asyncio
 async def test_custom_search_params_with_facet_filters(index_with_documents):
     index = await index_with_documents()
-    update = await index.update_attributes_for_faceting(["genre"])
+    update = await index.update_filterable_attributes(["genre"])
     await index.wait_for_pending_update(update.update_id)
-    response = await index.search("world", facet_filters=[["genre:action"]])
+    response = await index.search("world", filter=[["genre = action"]])
     assert len(response.hits) == 3
     assert response.facets_distribution is None
     assert response.exhaustive_facets_count is None
@@ -126,16 +127,17 @@ async def test_custom_search_params_with_facet_filters(index_with_documents):
 @pytest.mark.asyncio
 async def test_custom_search_params_with_multiple_facet_filters(index_with_documents):
     index = await index_with_documents()
-    update = await index.update_attributes_for_faceting(["genre"])
+    update = await index.update_filterable_attributes(["genre"])
     await index.wait_for_pending_update(update.update_id)
     response = await index.search(
-        "world", facet_filters=["genre:action", ["genre:action", "genre:action"]]
+        "world", filter=["genre = action", ["genre = action", "genre = action"]]
     )
     assert len(response.hits) == 3
     assert response.facets_distribution is None
     assert response.exhaustive_facets_count is None
 
 
+@pytest.mark.xfail(reason="filter with space not working")
 @pytest.mark.asyncio
 async def test_custom_search_facet_filters_with_space(test_client):
     dataset = [
@@ -181,9 +183,9 @@ async def test_custom_search_facet_filters_with_space(test_client):
     index = test_client.index("books")
     update = await index.add_documents(dataset)
     await index.wait_for_pending_update(update.update_id)
-    update = await index.update_attributes_for_faceting(["genre"])
+    update = await index.update_filterable_attributes(["genre"])
     await index.wait_for_pending_update(update.update_id)
-    response = await index.search("h", facet_filters=["genre:sci fi"])
+    response = await index.search("h", filter=["genre = sci fi"])
     assert len(response.hits) == 1
     assert response.hits[0]["title"] == "The Hobbit"
 
@@ -191,10 +193,10 @@ async def test_custom_search_facet_filters_with_space(test_client):
 @pytest.mark.asyncio
 async def test_custom_search_params_with_many_params(index_with_documents):
     index = await index_with_documents()
-    update = await index.update_attributes_for_faceting(["genre"])
+    update = await index.update_filterable_attributes(["genre"])
     await index.wait_for_pending_update(update.update_id)
     response = await index.search(
-        "world", facet_filters=[["genre:action"]], attributes_to_retrieve=["title", "poster"]
+        "world", filter=[["genre = action"]], attributes_to_retrieve=["title", "poster"]
     )
     assert len(response.hits) == 3
     assert response.facets_distribution is None

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -80,7 +80,6 @@ async def test_custom_search_params_with_simple_string(index_with_documents):
     assert "release_date" not in response.hits[0]["_formatted"]
 
 
-@pytest.mark.xfail(reason="attributes_to_highlight not working")
 @pytest.mark.asyncio
 async def test_custom_search_params_with_string_list(index_with_documents):
     index = await index_with_documents()
@@ -94,8 +93,8 @@ async def test_custom_search_params_with_string_list(index_with_documents):
     assert "title" in response.hits[0]
     assert "overview" in response.hits[0]
     assert "release_date" not in response.hits[0]
-    assert "title" in response.hits[0]["_formatted"]
-    assert "overview" not in response.hits[0]["_formatted"]
+    assert "<em>" in response.hits[0]["_formatted"]["title"]
+    assert "<em>" not in response.hits[0]["_formatted"]["overview"]
 
 
 @pytest.mark.asyncio
@@ -137,7 +136,6 @@ async def test_custom_search_params_with_multiple_facet_filters(index_with_docum
     assert response.exhaustive_facets_count is None
 
 
-@pytest.mark.xfail(reason="filter with space not working")
 @pytest.mark.asyncio
 async def test_custom_search_facet_filters_with_space(test_client):
     dataset = [
@@ -185,7 +183,7 @@ async def test_custom_search_facet_filters_with_space(test_client):
     await index.wait_for_pending_update(update.update_id)
     update = await index.update_filterable_attributes(["genre"])
     await index.wait_for_pending_update(update.update_id)
-    response = await index.search("h", filter=["genre = sci fi"])
+    response = await index.search("h", filter=["genre = 'sci fi'"])
     assert len(response.hits) == 1
     assert response.hits[0]["title"] == "The Hobbit"
 


### PR DESCRIPTION
# :warning: Don't merge until MeiliSearch v0.21.0 is released :warning: 

## Breaking Changes
- `filters` and `facets_filter` parameters search parameters are removed and replaced by the `filter` parameter.
When using `filter`, the `genre: comedy` syntax is not available. Use `genre = comedy` instead. The result will be the same as in the previous versions.
Both the `filters` and `facets_filter` syntax are available:
  - string:  `"genre = comedy AND price > 13" `
  - list: `["genre = comedy", "price > 13 "] `
- `fields_distribution` is renamed to `field_distribution`
- `build_date` is renamed to `commit_date` and changed from a `datetime` to at `date` in `Version`.
- To be used in the filter parameters, an attribute has to be set in `filterable_attributes`.
- The settings `attributes_for_faceting` is renamed to `filterable_attributes`.
- The new default ranking rules are:

```py
[
    "words",
    "typo",
    "proximity",
    "attribute",
    "exactness"
]
```