### PR TITLE
Adding auto batching of documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,46 @@ SearchResults(
   response = await index.update_documents_from_file("/path/to/file.json")
   ```
 
+* add_documents_auto_batch:
+
+  Automatically split document into batches when adding documents. The auto batcher puts as may
+  documents as possible into the batch while fitting under the maximum payload size (default is 100MB)
+
+  ```py
+  index = test_client.index("movies")
+  response = await index.add_documents_auto_batch(documents)
+  ```
+
+* add_documents_from_file_auto_batch:
+
+  Automatically split document into batches when adding documents from a file. The auto batcher puts
+  as may documents as possible into the batch while fitting under the maximum payload size (default is 100MB)
+
+  ```py
+  index = test_client.index("movies")
+  response = await index.add_documents_from_file_auto_batch("/path/to/file.json")
+  ```
+
+* update_documents_auto_batch:
+
+  Automatically split document into batches when updating documents. The auto batcher puts as may
+  documents as possible into the batch while fitting under the maximum payload size (default is 100MB)
+
+  ```py
+  index = test_client.index("movies")
+  response = await index.update_documents_auto_batch(documents)
+  ```
+
+* update_documents_from_file_auto_batch:
+
+  Automatically split document into batches when updating documents from a file. The auto batcher
+  puts as may documents as possible into the batch while fitting under the maximum payload size (default is 100MB)
+
+  ```py
+  index = test_client.index("movies")
+  response = await index.update_documents_from_file_auto_batch("/path/to/file.json")
+  ```
+
 ## Compatibility with MeiliSearch
 
 This package only guarantees the compatibility with [version v0.20.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.20.0).

--- a/meilisearch_python_async/errors.py
+++ b/meilisearch_python_async/errors.py
@@ -44,3 +44,9 @@ class MeiliSearchTimeoutError(MeiliSearchError):
 
     def __str__(self) -> str:
         return f"MeiliSearchTimeoutError, {self.message}"
+
+
+class PayloadTooLarge(Exception):
+    """Error when the payload is larger than the allowed payload size"""
+
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "meilisearch-python-async"
-version = "0.10.0"
+version = "0.11.0"
 description = "A Python async client for the MeiliSearch API"
 authors = ["Paul Sanders <psanders1@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
`add_documents_auto_batch`, `add_documents_from_file_auto_batch`, `add_documents_auto_batch`, and `add_documents_from_file_auto_batch` methods added to the `Index` to automatically split documents into batches when indexing.