### PR TITLE
Fixed issue where large documents were timing out

### DIFF
--- a/meilisearch_python_async/client.py
+++ b/meilisearch_python_async/client.py
@@ -14,7 +14,7 @@ from meilisearch_python_async.models import ClientStats, DumpInfo, Health, Index
 class Client:
     """The client to connect to the MeiliSearchApi."""
 
-    def __init__(self, url: str, api_key: str = None, timeout: int = 5) -> None:
+    def __init__(self, url: str, api_key: str = None, timeout: int | None = None) -> None:
         """Class initializer.
 
         Args:


### PR DESCRIPTION
When larger documents were being send httpx was timing out. To fix this I overrode the default timeout of 5 seconds and set it to none.