### PR TITLE
Changed commit_date type in Version to datetime to match the new MeiliSearch type

### DIFF
--- a/meilisearch_python_async/models/version.py
+++ b/meilisearch_python_async/models/version.py
@@ -1,9 +1,9 @@
-from datetime import date
+from datetime import datetime
 
 from camel_converter.pydantic_base import CamelBase
 
 
 class Version(CamelBase):
     commit_sha: str
-    commit_date: date
+    commit_date: datetime
     pkg_version: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "meilisearch-python-async"
-version = "0.13.0"
+version = "0.13.1"
 description = "A Python async client for the MeiliSearch API"
 authors = ["Paul Sanders <psanders1@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
MeiliSearch has gone back to returning a date time for commit_date so the type needed to be updated.