### PR TITLE
Change to named parameters

### DIFF
--- a/meilisearch_python_async/client.py
+++ b/meilisearch_python_async/client.py
@@ -14,7 +14,7 @@ from meilisearch_python_async.models import ClientStats, DumpInfo, Health, Index
 class Client:
     """The client to connect to the MeiliSearchApi."""
 
-    def __init__(self, url: str, api_key: str | None = None, timeout: int | None = None) -> None:
+    def __init__(self, url: str, api_key: str | None = None, *, timeout: int | None = None) -> None:
         """Class initializer.
 
         **Args:**

--- a/meilisearch_python_async/index.py
+++ b/meilisearch_python_async/index.py
@@ -124,12 +124,12 @@ class Index:
                 raise error
             return False
 
-    async def update(self, primary_key: str | None = None) -> Index:
+    async def update(self, primary_key: str) -> Index:
         """Update the index primary key.
 
         **Args:**
 
-        * **primary_key:** The primary key of the documents. Defaults to None.
+        * **primary_key:** The primary key of the documents.
 
         **Returns:** An instance of the Index with the updated information.
 
@@ -147,10 +147,7 @@ class Index:
         >>>     updated_index = await index.update()
         ```
         """
-        payload = {}
-        if primary_key is not None:
-            payload["primaryKey"] = primary_key
-
+        payload = {"primaryKey": primary_key}
         url = f"{self._base_url_with_uid}"
         response = await self._http_requests.put(url, payload)
         self.primary_key = response.json()["primaryKey"]
@@ -313,7 +310,7 @@ class Index:
         return UpdateStatus(**response.json())
 
     async def wait_for_pending_update(
-        self, update_id: int, timeout_in_ms: int = 5000, interval_in_ms: int = 50
+        self, update_id: int, *, timeout_in_ms: int = 5000, interval_in_ms: int = 50
     ) -> UpdateStatus:
         """Wait until MeiliSearch processes an update, and get its status.
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -232,7 +232,7 @@ async def test_bad_master_key(base_url, master_key):
 @pytest.mark.asyncio
 async def test_communication_error(master_key):
     with pytest.raises(MeiliSearchCommunicationError):
-        async with Client("http://wrongurl:1234", master_key, 1) as client:
+        async with Client("http://wrongurl:1234", master_key, timeout=1) as client:
             await client.create_index("some_index")
 
 


### PR DESCRIPTION
- Made `time_out` in client `__init__` a named parameter
- Made `primary_key` required in the index `update`
- Made `timeout_in_ms` and `interval_in_ms` in `wait_for_pending_update` named parameters