### PR TITLE
Add Pagination Settings

### DIFF
--- a/meilisearch_python_async/index.py
+++ b/meilisearch_python_async/index.py
@@ -17,7 +17,12 @@ from meilisearch_python_async.errors import InvalidDocumentError, MeiliSearchErr
 from meilisearch_python_async.models.documents import DocumentsInfo
 from meilisearch_python_async.models.index import IndexStats
 from meilisearch_python_async.models.search import SearchResults
-from meilisearch_python_async.models.settings import Faceting, MeiliSearchSettings, TypoTolerance
+from meilisearch_python_async.models.settings import (
+    Faceting,
+    MeiliSearchSettings,
+    Pagination,
+    TypoTolerance,
+)
 from meilisearch_python_async.models.task import TaskInfo
 from meilisearch_python_async.task import wait_for_task
 
@@ -2105,6 +2110,79 @@ class Index:
             >>>     await index.reset_faceting()
         """
         url = f"{self._settings_url}/faceting"
+        response = await self._http_requests.delete(url)
+
+        return TaskInfo(**response.json())
+
+    async def get_pagination(self) -> Pagination:
+        """Get pagination settings for the index.
+
+        Returns:
+
+            Pagination for the index.
+
+        Raises:
+
+            MeilisearchCommunicationError: If there was an error communicating with the server.
+            MeilisearchApiError: If the MeiliSearch API returned an error.
+
+        Examples:
+
+            >>> from meilisearch_async_client import Client
+            >>> async with Client("http://localhost.com", "masterKey") as client:
+            >>>     index = client.index("movies")
+            >>>     pagination_settings = await index.get_pagination()
+        """
+        url = f"{self._settings_url}/pagination"
+        response = await self._http_requests.get(url)
+
+        return Pagination(**response.json())
+
+    async def update_pagination(self, settings: Pagination) -> TaskInfo:
+        """Partially update the pagination settings for an index.
+
+        Returns:
+
+            Task to track the action.
+
+        Raises:
+
+            MeilisearchCommunicationError: If there was an error communicating with the server.
+            MeilisearchApiError: If the MeiliSearch API returned an error.
+
+        Examples:
+
+            >>> from meilisearch_python_async import Client
+            >>> from meilisearch_python_async.models.settings import Pagination
+            >>> async with Client("http://localhost.com", "masterKey") as client:
+            >>>     index = client.index("movies")
+            >>>     await index.update_pagination(settings=Pagination(max_total_hits=123))
+        """
+        url = f"{self._settings_url}/pagination"
+        response = await self._http_requests.patch(url, settings.dict(by_alias=True))
+
+        return TaskInfo(**response.json())
+
+    async def reset_pagination(self) -> TaskInfo:
+        """Reset an index's pagination settings to their default value.
+
+        Returns:
+
+            The details of the task status.
+
+        Raises:
+
+            MeilisearchCommunicationError: If there was an error communicating with the server.
+            MeilisearchApiError: If the MeiliSearch API returned an error.
+
+        Examples:
+
+            >>> from meilisearch_async_client import Client
+            >>> async with Client("http://localhost.com", "masterKey") as client:
+            >>>     index = client.index("movies")
+            >>>     await index.reset_pagination()
+        """
+        url = f"{self._settings_url}/pagination"
         response = await self._http_requests.delete(url)
 
         return TaskInfo(**response.json())

--- a/meilisearch_python_async/models/settings.py
+++ b/meilisearch_python_async/models/settings.py
@@ -19,6 +19,10 @@ class Faceting(CamelBase):
     max_values_per_facet: int
 
 
+class Pagination(CamelBase):
+    max_total_hits: int
+
+
 class MeiliSearchSettings(CamelBase):
     synonyms: Optional[Dict[str, Any]] = None
     stop_words: Optional[List[str]] = None
@@ -30,3 +34,4 @@ class MeiliSearchSettings(CamelBase):
     sortable_attributes: Optional[List[str]] = None
     typo_tolerance: Optional[TypoTolerance] = None
     faceting: Optional[Faceting] = None
+    pagination: Optional[Pagination] = None

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -8,9 +8,9 @@ from meilisearch_python_async.errors import MeiliSearchApiError
 from meilisearch_python_async.index import _iso_to_date_time
 from meilisearch_python_async.models.settings import (
     Faceting,
-    Pagination,
     MeiliSearchSettings,
     MinWordSizeForTypos,
+    Pagination,
     TypoTolerance,
 )
 from meilisearch_python_async.task import wait_for_task
@@ -124,7 +124,9 @@ async def test_get_stats(empty_index, small_movies):
     assert response.number_of_documents == 30
 
 
-async def test_get_settings_default(empty_index, default_ranking_rules, default_faceting, default_pagination):
+async def test_get_settings_default(
+    empty_index, default_ranking_rules, default_faceting, default_pagination
+):
     index = await empty_index()
     response = await index.get_settings()
     assert response.ranking_rules == default_ranking_rules


### PR DESCRIPTION
Closes #282.

- [x] Add model for pagination details in the [settings models](https://github.com/sanders41/meilisearch-python-async/blob/main/meilisearch_python_async/models/settings.py)

- [x] Add new methods for pagination setting to the [index](https://github.com/sanders41/meilisearch-python-async/blob/main/meilisearch_python_async/index.py)
   - [x] GET
   - [x] PATCH
   - [x] DELETE

- [x] Add [tests](https://github.com/sanders41/meilisearch-python-async/blob/main/tests/test_index.py)

Sorry if I couldn't get to add tests for pagination settings, I don't have docker installed in my machine.. my bad 😅. Can you add the tests yourself?

But I did use all the functions myself (via a cloud instance with the [`small_movies` dataset](/sanders41/meilisearch-python-async/blob/main/datasets/small_movies.json)) and it worked fantastically.

