### PR TITLE
Add new search parameters and result fields

### DIFF
--- a/meilisearch_python_async/index.py
+++ b/meilisearch_python_async/index.py
@@ -296,6 +296,8 @@ class Index:
         highlight_post_tag: str = "</em>",
         crop_marker: str = "...",
         matching_strategy: str = "all",
+        hits_per_page: int | None = None,
+        page: int | None = None,
     ) -> SearchResults:
         """Search the index.
 
@@ -320,6 +322,8 @@ class Index:
             crop_marker: Marker to display when the number of words excedes the `crop_length`.
                 Defaults to ...
             matching_strategy: Specifies the matching strategy Meilisearch should use. Defaults to `all`.
+            hits_per_page: Sets the number of results returned per page.
+            page: Sets the specific results page to fetch.
 
         Returns:
 
@@ -353,6 +357,8 @@ class Index:
             "highlightPostTag": highlight_post_tag,
             "cropMarker": crop_marker,
             "matchingStrategy": matching_strategy,
+            "hitsPerPage": hits_per_page,
+            "page": page,
         }
         url = f"{self._base_url_with_uid}/search"
         response = await self._http_requests.post(url, body=body)

--- a/meilisearch_python_async/models/search.py
+++ b/meilisearch_python_async/models/search.py
@@ -5,9 +5,13 @@ from camel_converter.pydantic_base import CamelBase
 
 class SearchResults(CamelBase):
     hits: List[Dict[str, Any]]
-    offset: int
-    limit: int
-    estimated_total_hits: int
+    offset: Optional[int]
+    limit: Optional[int]
+    estimated_total_hits: Optional[int]
     processing_time_ms: float
     query: str
     facet_distribution: Optional[Dict[str, Any]] = None
+    total_pages: Optional[int]
+    total_hits: Optional[int]
+    page: Optional[int]
+    hits_per_page: Optional[int]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -208,6 +208,29 @@ async def test_custom_search_facet_filters_with_space(test_client):
     assert response.hits[0]["title"] == "The Hobbit"
 
 
+async def test_custom_search_params_with_pagination_parameters(index_with_documents):
+    index = await index_with_documents()
+    response = await index.search("", hits_per_page=1, page=1)
+
+    assert len(response.hits) == 1
+    assert response.hits_per_page == 1
+    assert response.page == 1
+    assert response.total_pages is not None
+    assert response.total_hits is not None
+
+
+async def test_custom_search_params_with_pagination_parameters_at_zero(index_with_documents):
+    index = await index_with_documents()
+    response = await index.search("", hits_per_page=0, page=0)
+
+    assert len(response.hits) == 0
+    assert response.hits_per_page == 0
+    assert response.page == 0
+    assert response.total_pages is not None
+    assert response.total_hits is not None
+    assert response.estimated_total_hits is None
+
+
 async def test_custom_search_params_with_many_params(index_with_documents):
     index = await index_with_documents()
     update = await index.update_filterable_attributes(["genre"])


### PR DESCRIPTION
- Add new `hits_per_page` and `page` parameters to search
- Adds `total_pages`,  `total_hits`, `page`, and `hits_per_page` to search results
- Makes `offset`, `limit`, `estimated_total_hits` optional in the search results