### PR TITLE
Add `verify` argument for `Client.__init__`

### DIFF
--- a/meilisearch_python_async/client.py
+++ b/meilisearch_python_async/client.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
+from ssl import SSLContext
 from types import TracebackType
 from typing import Any, Type
 
 import jwt
 from httpx import AsyncClient
-from ssl import SSLContext
 
 from meilisearch_python_async._http_requests import HttpRequests
 from meilisearch_python_async.errors import InvalidRestriction, MeiliSearchApiError

--- a/meilisearch_python_async/client.py
+++ b/meilisearch_python_async/client.py
@@ -39,6 +39,9 @@ class Client:
             api_key: The optional API key for MeiliSearch. Defaults to None.
             timeout: The amount of time in seconds that the client will wait for a response before
                 timing out. Defaults to None.
+            verify: SSL certificates (a.k.a CA bundle) used to
+                verify the identity of requested hosts. Either `True` (default CA bundle),
+                a path to an SSL certificate file, or `False` (disable verification)
         """
         if api_key:
             headers = {"Authorization": f"Bearer {api_key}"}

--- a/meilisearch_python_async/client.py
+++ b/meilisearch_python_async/client.py
@@ -22,7 +22,14 @@ from meilisearch_python_async.task import wait_for_task
 class Client:
     """The client to connect to the MeiliSearchApi."""
 
-    def __init__(self, url: str, api_key: str | None = None, *, timeout: int | None = None, verify: bool = True) -> None:
+    def __init__(
+        self,
+        url: str,
+        api_key: str | None = None,
+        *,
+        timeout: int | None = None,
+        verify: bool = True,
+    ) -> None:
         """Class initializer.
 
         Args:
@@ -37,7 +44,9 @@ class Client:
         else:
             headers = None
 
-        self.http_client = AsyncClient(base_url=url, timeout=timeout, headers=headers, verify=verify)
+        self.http_client = AsyncClient(
+            base_url=url, timeout=timeout, headers=headers, verify=verify
+        )
         self._http_requests = HttpRequests(self.http_client)
 
     async def __aenter__(self) -> Client:

--- a/meilisearch_python_async/client.py
+++ b/meilisearch_python_async/client.py
@@ -22,7 +22,7 @@ from meilisearch_python_async.task import wait_for_task
 class Client:
     """The client to connect to the MeiliSearchApi."""
 
-    def __init__(self, url: str, api_key: str | None = None, *, timeout: int | None = None) -> None:
+    def __init__(self, url: str, api_key: str | None = None, *, timeout: int | None = None, verify: bool = True) -> None:
         """Class initializer.
 
         Args:
@@ -37,7 +37,7 @@ class Client:
         else:
             headers = None
 
-        self.http_client = AsyncClient(base_url=url, timeout=timeout, headers=headers)
+        self.http_client = AsyncClient(base_url=url, timeout=timeout, headers=headers, verify=verify)
         self._http_requests = HttpRequests(self.http_client)
 
     async def __aenter__(self) -> Client:

--- a/meilisearch_python_async/client.py
+++ b/meilisearch_python_async/client.py
@@ -29,7 +29,7 @@ class Client:
         api_key: str | None = None,
         *,
         timeout: int | None = None,
-        verify: VerifyTypes = True,
+        verify: str | bool | SSLContext = True,
     ) -> None:
         """Class initializer.
 

--- a/meilisearch_python_async/client.py
+++ b/meilisearch_python_async/client.py
@@ -7,7 +7,7 @@ from typing import Any, Type
 
 import jwt
 from httpx import AsyncClient
-from httpx._types import VerifyTypes
+from ssl import SSLContext
 
 from meilisearch_python_async._http_requests import HttpRequests
 from meilisearch_python_async.errors import InvalidRestriction, MeiliSearchApiError

--- a/meilisearch_python_async/client.py
+++ b/meilisearch_python_async/client.py
@@ -7,6 +7,7 @@ from typing import Any, Type
 
 import jwt
 from httpx import AsyncClient
+from httpx._types import VerifyTypes
 
 from meilisearch_python_async._http_requests import HttpRequests
 from meilisearch_python_async.errors import InvalidRestriction, MeiliSearchApiError
@@ -28,7 +29,7 @@ class Client:
         api_key: str | None = None,
         *,
         timeout: int | None = None,
-        verify: bool = True,
+        verify: VerifyTypes = True,
     ) -> None:
         """Class initializer.
 


### PR DESCRIPTION
Turning off ssl verification when using http can save a lot of resources