### PR TITLE
Change utcnow to now with time zone

### DIFF
--- a/meilisearch_python_async/client.py
+++ b/meilisearch_python_async/client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from ssl import SSLContext
 from types import TracebackType
 from typing import Any, Type
@@ -185,10 +185,10 @@ class Client:
 
         Examples:
 
-            >>> from datetime import datetime, timedelta
+            >>> from datetime import datetime, timedelta, timezone
             >>> from meilisearch_python_async import Client
             >>>
-            >>> expires_at = datetime.utcnow() + timedelta(days=7)
+            >>> expires_at = datetime.now(tz=timezone.utc) + timedelta(days=7)
             >>>
             >>> async with Client("http://localhost.com", "masterKey") as client:
             >>>     token = client.generate_tenant_token(
@@ -209,7 +209,7 @@ class Client:
 
         payload["apiKeyUid"] = api_key.uid
         if expires_at:
-            if expires_at <= datetime.utcnow():
+            if expires_at <= datetime.now(tz=timezone.utc):
                 raise ValueError("expires_at must be a time in the future")
 
             payload["exp"] = int(datetime.timestamp(expires_at))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from asyncio import sleep
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import jwt
@@ -122,7 +122,7 @@ async def test_generate_tenant_token_default_key(test_client, default_search_key
 
 async def test_generate_tenant_token_default_key_expires(test_client, default_search_key):
     search_rules: dict[str, Any] = {"test": "value"}
-    expires_at = datetime.utcnow() + timedelta(days=1)
+    expires_at = datetime.now(tz=timezone.utc) + timedelta(days=1)
     expected: dict[str, Any] = {"searchRules": search_rules}
     expected["apiKeyUid"] = default_search_key.uid
     expected["exp"] = int(datetime.timestamp(expires_at))
@@ -134,7 +134,7 @@ async def test_generate_tenant_token_default_key_expires(test_client, default_se
 
 async def test_generate_tenant_token_default_key_expires_past(test_client, default_search_key):
     search_rules: dict[str, Any] = {"test": "value"}
-    expires_at = datetime.utcnow() + timedelta(days=-1)
+    expires_at = datetime.now(tz=timezone.utc) + timedelta(days=-1)
     with pytest.raises(ValueError):
         test_client.generate_tenant_token(
             search_rules, api_key=default_search_key, expires_at=expires_at
@@ -272,7 +272,7 @@ async def test_health(test_client):
 
 
 async def test_create_key(test_key_info, test_client):
-    expires_at = datetime.utcnow() + timedelta(days=2)
+    expires_at = datetime.now(tz=timezone.utc) + timedelta(days=2)
     test_key_info.expires_at = expires_at
     key = await test_client.create_key(test_key_info)
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -291,7 +291,7 @@ async def test_search_with_tenant_token(
 async def test_search_with_tenant_token_and_expire_date(
     test_client, index_with_documents, base_url, index_uid, default_search_key
 ):
-    expires_at = datetime.utcnow() + timedelta(days=1)
+    expires_at = datetime.now(tz=timezone.utc) + timedelta(days=1)
     token = test_client.generate_tenant_token(
         search_rules=["*"], api_key=default_search_key, expires_at=expires_at
     )


### PR DESCRIPTION
`utcnow` is being [depreciated](https://github.com/python/cpython/issues/103857) in Python 3.12