### PR TITLE
Fix potential json_encoding date error in pydantic < 2

### DIFF
--- a/meilisearch_python_async/models/client.py
+++ b/meilisearch_python_async/models/client.py
@@ -53,7 +53,13 @@ class _KeyBase(CamelBase):
 
         class Config:
             json_encoders = {
-                datetime: lambda v: None if not v else f"{str(v).split('.')[0].replace(' ', 'T')}Z"
+                datetime: lambda v: None
+                if not v
+                else (
+                    f"{str(v).split('+')[0].replace(' ', 'T')}Z"
+                    if "+" in str(v)
+                    else f"{str(v).split('.')[0].replace(' ', 'T')}Z"
+                )
             }
 
 
@@ -111,7 +117,13 @@ class KeyCreate(CamelBase):
 
         class Config:
             json_encoders = {
-                datetime: lambda v: None if not v else f"{str(v).split('.')[0].replace(' ', 'T')}Z"
+                datetime: lambda v: None
+                if not v
+                else (
+                    f"{str(v).split('+')[0].replace(' ', 'T')}Z"
+                    if "+" in str(v)
+                    else f"{str(v).split('.')[0].replace(' ', 'T')}Z"
+                )
             }
 
 
@@ -130,7 +142,13 @@ class KeyUpdate(CamelBase):
 
         class Config:
             json_encoders = {
-                datetime: lambda v: None if not v else f"{str(v).split('.')[0].replace(' ', 'T')}Z"
+                datetime: lambda v: None
+                if not v
+                else (
+                    f"{str(v).split('+')[0].replace(' ', 'T')}Z"
+                    if "+" in str(v)
+                    else f"{str(v).split('.')[0].replace(' ', 'T')}Z"
+                )
             }
 
 


### PR DESCRIPTION
When dates ended in the format `+00:00` instead of `Z` the Pydantic `json_encoder` was throwing errors with Pydantic < 2