### PR TITLE
fix: http request when body is empty dict

### DIFF
--- a/meilisearch_python_sdk/_http_requests.py
+++ b/meilisearch_python_sdk/_http_requests.py
@@ -34,7 +34,7 @@ class AsyncHttpRequests:
     ) -> Response:
         headers = build_headers(content_type)
         try:
-            if not body:
+            if body is None:
                 response = await http_method(path)
             elif content_type == "application/json":
                 response = await http_method(path, json=body, headers=headers)


### PR DESCRIPTION
fix: https://github.com/long2ice/meilisync-admin/issues/5