### PR TITLE
RestEmbedder: Allow response to be a list as well as a dict

### DIFF
--- a/meilisearch_python_sdk/models/settings.py
+++ b/meilisearch_python_sdk/models/settings.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Literal, Any
+from typing import Any, Literal
 
 from camel_converter.pydantic_base import CamelBase
 from pydantic import field_validator, model_validator

--- a/meilisearch_python_sdk/models/settings.py
+++ b/meilisearch_python_sdk/models/settings.py
@@ -94,7 +94,7 @@ class RestEmbedder(CamelBase):
     distribution: Distribution | None = None
     headers: JsonDict | None = None
     request: JsonDict
-    response: JsonDict
+    response: JsonDict | list
     binary_quantized: bool | None = None
     indexing_fragments: JsonDict | None = None
     search_fragment: JsonDict | None = None

--- a/meilisearch_python_sdk/models/settings.py
+++ b/meilisearch_python_sdk/models/settings.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Literal
+from typing import Literal, Any
 
 from camel_converter.pydantic_base import CamelBase
 from pydantic import field_validator, model_validator
@@ -94,7 +94,7 @@ class RestEmbedder(CamelBase):
     distribution: Distribution | None = None
     headers: JsonDict | None = None
     request: JsonDict
-    response: JsonDict | list
+    response: JsonDict | list[Any]
     binary_quantized: bool | None = None
     indexing_fragments: JsonDict | None = None
     search_fragment: JsonDict | None = None


### PR DESCRIPTION
The huggingface text-embeddings-inference server returns embeddings as a list of vectors. In order to configure Meilisearch accordingly, the RestEmbedder must be declared 

`RestEmbedder(response=["{{embedding}}", "{{..}}"],...)`

Currently RestEmbedder.response requires a JsonDict. This patch permits a list as well.