### PR TITLE
fix: add facet_stats to search results

### DIFF
--- a/meilisearch_python_sdk/models/search.py
+++ b/meilisearch_python_sdk/models/search.py
@@ -89,6 +89,7 @@ class SearchResults(CamelBase, Generic[T]):
     processing_time_ms: int
     query: str
     facet_distribution: JsonDict | None = None
+    facet_stats: JsonDict | None = None
     total_pages: int | None = None
     total_hits: int | None = None
     page: int | None = None
@@ -109,6 +110,7 @@ class SearchResultsFederated(CamelBase, Generic[T]):
     estimated_total_hits: int | None = None
     processing_time_ms: int
     facet_distribution: JsonDict | None = None
+    facet_stats: JsonDict | None = None
     total_pages: int | None = None
     total_hits: int | None = None
     page: int | None = None

--- a/tests/test_async_search.py
+++ b/tests/test_async_search.py
@@ -159,6 +159,17 @@ async def test_custom_search_params_with_facets(async_index_with_documents):
     assert response.facet_distribution["genre"]["fantasy"] == 1
 
 
+async def test_custom_search_params_with_facet_stats(async_index_with_documents):
+    index = await async_index_with_documents()
+    update = await index.update_filterable_attributes(["release_date"])
+    await async_wait_for_task(index.http_client, update.task_uid, json_handler=index._json_handler)
+    response = await index.search("", facets=["release_date"])
+    assert response.facet_stats is not None
+    assert "release_date" in response.facet_stats
+    assert "min" in response.facet_stats["release_date"]
+    assert "max" in response.facet_stats["release_date"]
+
+
 async def test_custom_search_params_with_facet_filters(async_index_with_documents):
     index = await async_index_with_documents()
     update = await index.update_filterable_attributes(["genre"])

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -159,6 +159,17 @@ def test_custom_search_params_with_facets(index_with_documents):
     assert response.facet_distribution["genre"]["fantasy"] == 1
 
 
+def test_custom_search_params_with_facet_stats(index_with_documents):
+    index = index_with_documents()
+    update = index.update_filterable_attributes(["release_date"])
+    wait_for_task(index.http_client, update.task_uid, json_handler=index._json_handler)
+    response = index.search("", facets=["release_date"])
+    assert response.facet_stats is not None
+    assert "release_date" in response.facet_stats
+    assert "min" in response.facet_stats["release_date"]
+    assert "max" in response.facet_stats["release_date"]
+
+
 def test_custom_search_params_with_facet_filters(index_with_documents):
     index = index_with_documents()
     update = index.update_filterable_attributes(["genre"])


### PR DESCRIPTION
### Description

This PR adds `facet_stats` to `SearchResults` and `SearchResultsFederated`.

Closes #1671 