### PR TITLE
Default to OrjsonHandler if orjson is installed

### DIFF
--- a/docs/json_handler.md
+++ b/docs/json_handler.md
@@ -44,6 +44,9 @@ with Client("http://127.0.0.1:7700", json_handler=BuiltinHandler(serializer=Cust
 
 ## orjson
 
+Note that if orjson is installed and no `json_handler` is secified, orjson is used as the handler
+by default.
+
 ### Example
 
 ```py

--- a/meilisearch_python_sdk/_client/_async_client.py
+++ b/meilisearch_python_sdk/_client/_async_client.py
@@ -87,7 +87,7 @@ class AsyncClient(BaseClient):
             json_handler: The module to use for json operations. The options are BuiltinHandler
                 (uses the json module from the standard library), or OrjsonHandler (uses orjson).
                 Note that in order use orjson the corresponding extra needs to be included.
-                Default: BuiltinHandler.
+                Default: OrjsonHandler if orjson is installed or BuiltinHandler if not.
             http2: Whether or not to use HTTP/2. Defaults to False.
         """
         super().__init__(api_key, custom_headers, json_handler)

--- a/meilisearch_python_sdk/_client/_base_client.py
+++ b/meilisearch_python_sdk/_client/_base_client.py
@@ -11,6 +11,11 @@ from meilisearch_python_sdk.models.client import (
 )
 from meilisearch_python_sdk.types import JsonDict
 
+try:
+    import orjson
+except ImportError:  # pragma: no cover
+    orjson = None  # type: ignore
+
 if TYPE_CHECKING:
     from meilisearch_python_sdk.types import JsonMapping
 
@@ -22,7 +27,13 @@ class BaseClient:
         custom_headers: dict[str, str] | None = None,
         json_handler: BuiltinHandler | OrjsonHandler | None = None,
     ) -> None:
-        self.json_handler = json_handler if json_handler else BuiltinHandler()
+        if json_handler is not None:
+            self.json_handler = json_handler
+        elif orjson is not None:
+            self.json_handler = OrjsonHandler()
+        else:
+            self.json_handler = BuiltinHandler()
+
         self._headers: dict[str, str] | None = None
         if api_key:
             self._headers = {"Authorization": f"Bearer {api_key}"}

--- a/meilisearch_python_sdk/_client/_client.py
+++ b/meilisearch_python_sdk/_client/_client.py
@@ -88,7 +88,7 @@ class Client(BaseClient):
             json_handler: The module to use for json operations. The options are BuiltinHandler
                 (uses the json module from the standard library), or OrjsonHandler (uses orjson).
                 Note that in order use orjson the corresponding extra needs to be included.
-                Default: BuiltinHandler.
+                Default: OrjsonHandler if orjson is installed or BuiltinHandler if not.
             http2: If set to True, the client will use HTTP/2. Defaults to False.
         """
         super().__init__(api_key, custom_headers, json_handler)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ from httpx2 import AsyncClient as HttpxAsyncClient
 from meilisearch_python_sdk import AsyncClient, Client
 from meilisearch_python_sdk._task import async_wait_for_task, wait_for_task
 from meilisearch_python_sdk.errors import MeilisearchApiError
-from meilisearch_python_sdk.json_handler import OrjsonHandler
+from meilisearch_python_sdk.json_handler import BuiltinHandler, OrjsonHandler
 from meilisearch_python_sdk.models.settings import (
     Embedders,
     Faceting,
@@ -59,7 +59,9 @@ def ssl_verify(http2_enabled):
 
 @pytest.fixture(scope="session")
 async def async_client(base_url, ssl_verify):
-    async with AsyncClient(base_url, MASTER_KEY, verify=ssl_verify) as client:
+    async with AsyncClient(
+        base_url, MASTER_KEY, json_handler=BuiltinHandler(), verify=ssl_verify
+    ) as client:
         yield client
 
 
@@ -79,7 +81,7 @@ async def async_client_with_plugins(base_url, ssl_verify):
 
 @pytest.fixture(scope="session")
 def client(base_url, ssl_verify):
-    with Client(base_url, MASTER_KEY, verify=ssl_verify) as client:
+    with Client(base_url, MASTER_KEY, json_handler=BuiltinHandler(), verify=ssl_verify) as client:
         yield client
 
 

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 from urllib.parse import quote_plus
 from uuid import uuid4
 
@@ -71,6 +72,23 @@ async def wait_for_dump_creation(
         time_delta = datetime.now() - start_time
         elapsed_time = time_delta.seconds * 1000 + time_delta.microseconds / 1000
     raise TimeoutError
+
+
+@pytest.mark.parametrize(
+    "json_handler, expected",
+    ((None, OrjsonHandler), (BuiltinHandler(), BuiltinHandler), (OrjsonHandler(), OrjsonHandler)),
+)
+def test_json_handler(json_handler, expected):
+    client = AsyncClient("http://localhost", "someKey", json_handler=json_handler)
+
+    assert isinstance(client.json_handler, expected)
+
+
+def test_default_json_handler_no_orjson():
+    with patch("meilisearch_python_sdk._client._base_client.orjson", None):
+        client = AsyncClient("http://localhost", "someKey")
+
+    assert isinstance(client.json_handler, BuiltinHandler)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from time import sleep
+from unittest.mock import patch
 from urllib.parse import quote_plus
 from uuid import uuid4
 
@@ -66,6 +67,23 @@ def wait_for_dump_creation(client, dump_uid, timeout_in_ms=10000.0, interval_in_
         time_delta = datetime.now() - start_time
         elapsed_time = time_delta.seconds * 1000 + time_delta.microseconds / 1000
     raise TimeoutError
+
+
+@pytest.mark.parametrize(
+    "json_handler, expected",
+    ((None, OrjsonHandler), (BuiltinHandler(), BuiltinHandler), (OrjsonHandler(), OrjsonHandler)),
+)
+def test_json_handler(json_handler, expected):
+    client = Client("http://localhost", "someKey", json_handler=json_handler)
+
+    assert isinstance(client.json_handler, expected)
+
+
+def test_default_json_handler_no_orjson():
+    with patch("meilisearch_python_sdk._client._base_client.orjson", None):
+        client = Client("http://localhost", "someKey")
+
+    assert isinstance(client.json_handler, BuiltinHandler)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Previously the default was always BuiltinHander, now if orjson is installed it will be used as the default json_handler