### PR TITLE
Speed up posting json when using orjson

### DIFF
--- a/meilisearch_python_sdk/_http_requests.py
+++ b/meilisearch_python_sdk/_http_requests.py
@@ -53,7 +53,7 @@ class AsyncHttpRequests:
                 response = await http_method(path)
             elif content_type == "application/json" and not compress:
                 response = await http_method(
-                    path, content=self.json_handler.dumps(body), headers=headers
+                    path, content=self.json_handler.dump_bytes(body), headers=headers
                 )
             else:
                 if compress:
@@ -141,7 +141,9 @@ class HttpRequests:
             if body is None:
                 response = http_method(path)
             elif content_type == "application/json" and not compress:
-                response = http_method(path, content=self.json_handler.dumps(body), headers=headers)
+                response = http_method(
+                    path, content=self.json_handler.dump_bytes(body), headers=headers
+                )
             else:
                 if compress:
                     if content_type == "application/json":

--- a/tests/test_json_handler.py
+++ b/tests/test_json_handler.py
@@ -1,0 +1,13 @@
+import json
+
+import pytest
+
+from meilisearch_python_sdk.json_handler import BuiltinHandler, OrjsonHandler
+
+
+@pytest.mark.parametrize("json_handler", (BuiltinHandler(), OrjsonHandler()))
+def test_dumps(json_handler):
+    result = json_handler.dumps({"id": 1, "title": "Shazam!"})
+
+    assert isinstance(result, str)
+    assert json.loads(result) == {"id": 1, "title": "Shazam!"}


### PR DESCRIPTION
This removes the double encoding of data when posting